### PR TITLE
updating-types

### DIFF
--- a/mojap_metadata/metadata/specs/table_schema.json
+++ b/mojap_metadata/metadata/specs/table_schema.json
@@ -103,7 +103,7 @@
                             {
                                 "properties": {
                                     "type": {
-                                        "pattern": "^(time|date)(32|64)$|^timestamp(\\((m|u|n)?s\\))?$"
+                                        "pattern": "^time32\\((s|ms)\\)$|^time64\\((us|ns)\\)$|^date(32|64)$|^timestamp\\((s|ms|us|ns)\\)$"
                                     }
                                 }
                             },
@@ -207,7 +207,7 @@
                                         "if": {
                                             "properties": {
                                                 "type": {
-                                                    "pattern": "^(time|date)(32|64)(\\(m?s\\))?$|^timestamp(\\((m|u|n)?s\\))?$"
+                                                    "pattern": "^time32\\((s|ms)\\)$|^time64\\((us|ns)\\)$|^date(32|64)$|^timestamp\\((s|ms|us|ns)\\)$"
                                                 }
                                             }
                                         },
@@ -311,7 +311,7 @@
                     "type": {
                         "type": "string",
                         "title": "The data type. Should be one of the Arrow types",
-                        "pattern": "^null$|^u?int(8|16|32|64)$|^float(16|32|64)$|^decimal128\\(\\d+,\\d+\\)$|^string$|^large_string$|^utf8$|^large_utf8$|^(time|date)(32|64)(\\(m?s\\))?$|^timestamp(\\((m|u|n)?s\\))?$|^binary(\\([0-9]+\\))?$|^large_binary$|^bool_$"
+                        "pattern": "^null$|^u?int(8|16|32|64)$|^float(16|32|64)$|^decimal128\\(\\d+,\\d+\\)$|^string$|^large_string$|^utf8$|^large_utf8$|^time32\\((s|ms)\\)$|^time64\\((us|ns)\\)$|^date(32|64)$|^timestamp\\((s|ms|us|ns)\\)$|^binary(\\([0-9]+\\))?$|^large_binary$|^bool_$"
                     },
                     "type_category": {
                         "type": "string",

--- a/mojap_metadata/metadata/specs/table_schema.json
+++ b/mojap_metadata/metadata/specs/table_schema.json
@@ -320,7 +320,6 @@
                             "integer",
                             "float",
                             "string",
-                            "date",
                             "datetime",
                             "boolean",
                             "array",

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -84,11 +84,10 @@ class TestMetadata:
             [{"name": "test", "type": "float32"}],
             [{"name": "test", "type": "float64"}],
             [{"name": "test", "type": "decimal128(0,38)"}],
-            [{"name": "test", "type": "time32"}],
-            [{"name": "test", "type": "time64"}],
-            [{"name": "test", "type": "time64(s)"}],
-            [{"name": "test", "type": "time64(ms)"}],
-            [{"name": "test", "type": "timestamp"}],
+            [{"name": "test", "type": "time32(s)"}],
+            [{"name": "test", "type": "time32(ms)"}],
+            [{"name": "test", "type": "time64(us)"}],
+            [{"name": "test", "type": "time64(ns)"}],
             [{"name": "test", "type": "timestamp(s)"}],
             [{"name": "test", "type": "timestamp(ms)"}],
             [{"name": "test", "type": "timestamp(us)"}],
@@ -106,7 +105,7 @@ class TestMetadata:
             [{"name": "test", "type_category": "integer", "type": "int8"}],
             [{"name": "test", "type_category": "float", "type": "float32"}],
             [{"name": "test", "type_category": "string", "type": "string"}],
-            [{"name": "test", "type_category": "datetime", "type": "timestamp"}],
+            [{"name": "test", "type_category": "datetime", "type": "timestamp(ms)"}],
             [{"name": "test", "type_category": "binary", "type": "binary(128)"}],
             [{"name": "test", "type_category": "binary", "type": "binary"}],
             [{"name": "test", "type_category": "boolean", "type": "bool_"}],
@@ -114,6 +113,19 @@ class TestMetadata:
     )
     def test_columns_pass(self, input: Any):
         Metadata(columns=input)
+
+    @pytest.mark.parametrize(
+        argnames="input",
+        argvalues=[
+            [{"name": "test", "type": "time32"}],
+            [{"name": "test", "type": "time64"}],
+            [{"name": "test", "type": "timestamp"}],
+            [{"name": "test", "type_category": "datetime", "type": "timestamp"}],
+        ],
+    )
+    def test_columns_fail(self, input: Any):
+        with pytest.raises(ValidationError):
+            Metadata(columns=input)
 
     def test_primary_key_and_partitions_attributes(self):
         pass


### PR DESCRIPTION
**Changes:**

- Updating metadata types to align with arrow (have to be explicit on unit for time and timestamps).
- Closes #8 
- Closes #26 (discussion on this PR)
- Removed date `type_category` from schema