### PR TITLE
Removing duplication from schema definition

### DIFF
--- a/mojap_metadata/metadata/specs/table_schema.json
+++ b/mojap_metadata/metadata/specs/table_schema.json
@@ -1,5 +1,324 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
+    "definitions": {
+        "additional_col_properties": {
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "title": "The column name"
+                },
+                "description": {
+                    "type": "string",
+                    "title": "A description of this field",
+                    "default": ""
+                },
+                "nullable": {
+                    "type": "boolean",
+                    "title": "Specifies if column is nullable (can have missing values) or not (cannot have missing values)"
+                },
+                "sensitive": {
+                    "type": "boolean",
+                    "title": "Specifies if the column contains personal or special category data"
+                },
+                "alias": {
+                    "type": "string",
+                    "title": "If this column contains a standard ID or other linking field but has a non-standard name, the alias can provide the standard name",
+                    "examples": [
+                        "nomis_id"
+                    ]
+                },
+                "foreign_key": {
+                    "type": "array",
+                    "title": "The list of foreign key relationships this column has, if any",
+                    "default": [],
+                    "examples": [
+                        [
+                            {
+                                "table": "",
+                                "columns": []
+                            }
+                        ]
+                    ],
+                    "items": {
+                        "anyOf": [
+                            {
+                                "type": "object",
+                                "default": {},
+                                "examples": [
+                                    {
+                                        "table": "",
+                                        "columns": []
+                                    }
+                                ],
+                                "required": [
+                                    "table",
+                                    "columns"
+                                ],
+                                "properties": {
+                                    "table": {
+                                        "type": "string",
+                                        "title": "The table name",
+                                        "default": "",
+                                        "examples": [
+                                            ""
+                                        ]
+                                    },
+                                    "columns": {
+                                        "type": "array",
+                                        "title": "The list of column names",
+                                        "default": []
+                                    }
+                                },
+                                "additionalProperties": true
+                            }
+                        ]
+                    }
+                },
+                "unique": {
+                    "type": "boolean",
+                    "title": "Specifies if the values in the column must be unique",
+                    "default": false
+                },
+                "enum": {
+                    "type": "array",
+                    "title": "An array of valid values that can exist in this column. Note NULL/None is not required, please use nullable property to define if column is nullable.",
+                    "examples": [
+                        [
+                            "Y",
+                            "N"
+                        ],
+                        [
+                            0,
+                            1,
+                            2,
+                            3,
+                            4
+                        ],
+                        [
+                            "England",
+                            "Northern Ireland",
+                            "Scotland",
+                            "Wales"
+                        ]
+                    ]
+                },
+                "pattern": {
+                    "type": "string",
+                    "title": "regex pattern that can be used to validate data in this column"
+                },
+                "minimum": {
+                    "type": [
+                        "null",
+                        "number"
+                    ],
+                    "title": "The minumum value a numerical type can take",
+                    "default": null
+                },
+                "maximum": {
+                    "type": [
+                        "null",
+                        "number"
+                    ],
+                    "title": "The maximum value a numerical type can take",
+                    "default": null
+                },
+                "minLength": {
+                    "type": [
+                        "null",
+                        "number"
+                    ],
+                    "title": "The minimum length a string type can have",
+                    "default": null
+                },
+                "maxLength": {
+                    "type": [
+                        "null",
+                        "number"
+                    ],
+                    "title": "The maximum length a string type can have",
+                    "default": null
+                }
+            },
+            "additionalProperties": true
+        },
+        "null_types": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/additional_col_properties"
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "pattern": "^null$"
+                        },
+                        "type_category": {
+                            "enum": [
+                                "null"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "int_types": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/additional_col_properties"
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "pattern": "^u?int(8|16|32|64)$"
+                        },
+                        "type_category": {
+                            "enum": [
+                                "integer"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "float_types": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/additional_col_properties"
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "pattern": "^float(16|32|64)$|^decimal128\\(\\d+,\\d+\\)$"
+                        },
+                        "type_category": {
+                            "enum": [
+                                "float"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "string_types": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/additional_col_properties"
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "pattern": "^string$|^large_string$|^utf8$|^large_utf8$"
+                        },
+                        "type_category": {
+                            "enum": [
+                                "string"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "timestamp_types": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/additional_col_properties"
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "pattern": "^time32\\((s|ms)\\)$|^time64\\((us|ns)\\)$|^date(32|64)$|^timestamp\\((s|ms|us|ns)\\)$"
+                        },
+                        "type_category": {
+                            "enum": [
+                                "timestamp"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "binary_types": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/additional_col_properties"
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "pattern": "^binary(\\([0-9]+\\))?$|^large_binary$"
+                        },
+                        "type_category": {
+                            "enum": [
+                                "binary"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "boolean_types": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/additional_col_properties"
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "pattern": "^bool_$"
+                        },
+                        "type_category": {
+                            "enum": [
+                                "boolean"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "list_types": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/additional_col_properties"
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "pattern": "^large_list<.+>$|^list_<.+>$"
+                        },
+                        "type_category": {
+                            "enum": [
+                                "list"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "struct_types": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "pattern": "^map_<.+>$|^struct<.+>$"
+                },
+                "type_category": {
+                    "enum": [
+                        "struct"
+                    ]
+                }
+            }
+        }
+    },
     "type": "object",
     "title": "Metadata",
     "description": "MoJ Data Catalogue Metadata",
@@ -47,415 +366,35 @@
             "type": "array",
             "title": "The columns in the table. An array of objects",
             "items": {
-                "type": "object",
-                "required": [
-                    "name"
-                ],
                 "oneOf": [
                     {
-                        "oneOf": [
-                            {
-                                "required": [
-                                    "type"
-                                ]
-                            },
-                            {
-                                "required": [
-                                    "type_category"
-                                ]
-                            }
-                        ]
+                        "$ref": "#/definitions/null_types"
                     },
                     {
-                        "required": [
-                            "type",
-                            "type_category"
-                        ],
-                        "oneOf": [
-                            {
-                                "properties": {
-                                    "type": {
-                                        "pattern": "^null$"
-                                    }
-                                }
-                            },
-                            {
-                                "properties": {
-                                    "type": {
-                                        "pattern": "^u?int(8|16|32|64)$"
-                                    }
-                                }
-                            },
-                            {
-                                "properties": {
-                                    "type": {
-                                        "pattern": "^float(16|32|64)$|^decimal128\\(\\d+,\\d+\\)$"
-                                    }
-                                }
-                            },
-                            {
-                                "properties": {
-                                    "type": {
-                                        "pattern": "^string$|^large_string$|^utf8$|^large_utf8$"
-                                    }
-                                }
-                            },
-                            {
-                                "properties": {
-                                    "type": {
-                                        "pattern": "^time32\\((s|ms)\\)$|^time64\\((us|ns)\\)$|^date(32|64)$|^timestamp\\((s|ms|us|ns)\\)$"
-                                    }
-                                }
-                            },
-                            {
-                                "properties": {
-                                    "type": {
-                                        "pattern": "^binary(\\([0-9]+\\))?$|^large_binary$"
-                                    }
-                                }
-                            },
-                            {
-                                "properties": {
-                                    "type": {
-                                        "pattern": "^bool_$"
-                                    }
-                                }
-                            },
-                            {
-                                "properties": {
-                                    "type": {
-                                        "pattern": "^list_\\(\\w+(,[0-9]+)?\\)$|^large_list\\(\\w+\\)$"
-                                    }
-                                }
-                            },
-                            {
-                                "properties": {
-                                    "type": {
-                                        "pattern": "^map_$|^struct$|^field$|^schema$"
-                                    }
-                                }
-                            }
-                        ],
-                        "if": {
-                            "properties": {
-                                "type": {
-                                    "pattern": "^null$"
-                                }
-                            }
-                        },
-                        "then": {
-                            "properties": {
-                                "type_category": {
-                                    "enum": [
-                                        "null"
-                                    ]
-                                }
-                            }
-                        },
-                        "else": {
-                            "if": {
-                                "properties": {
-                                    "type": {
-                                        "pattern": "^u?int(8|16|32|64)$"
-                                    }
-                                }
-                            },
-                            "then": {
-                                "properties": {
-                                    "type_category": {
-                                        "enum": [
-                                            "integer"
-                                        ]
-                                    }
-                                }
-                            },
-                            "else": {
-                                "if": {
-                                    "properties": {
-                                        "type": {
-                                            "pattern": "^float(16|32|64)$|^decimal128\\(\\d+,\\d+\\)$"
-                                        }
-                                    }
-                                },
-                                "then": {
-                                    "properties": {
-                                        "type_category": {
-                                            "enum": [
-                                                "float"
-                                            ]
-                                        }
-                                    }
-                                },
-                                "else": {
-                                    "if": {
-                                        "properties": {
-                                            "type": {
-                                                "pattern": "^string$|^large_string$|^utf8$|^large_utf8$"
-                                            }
-                                        }
-                                    },
-                                    "then": {
-                                        "properties": {
-                                            "type_category": {
-                                                "enum": [
-                                                    "string"
-                                                ]
-                                            }
-                                        }
-                                    },
-                                    "else": {
-                                        "if": {
-                                            "properties": {
-                                                "type": {
-                                                    "pattern": "^time32\\((s|ms)\\)$|^time64\\((us|ns)\\)$|^date(32|64)$|^timestamp\\((s|ms|us|ns)\\)$"
-                                                }
-                                            }
-                                        },
-                                        "then": {
-                                            "properties": {
-                                                "type_category": {
-                                                    "enum": [
-                                                        "datetime"
-                                                    ]
-                                                }
-                                            }
-                                        },
-                                        "else": {
-                                            "if": {
-                                                "properties": {
-                                                    "type": {
-                                                        "pattern": "^binary(\\([0-9]+\\))?$|^large_binary$"
-                                                    }
-                                                }
-                                            },
-                                            "then": {
-                                                "properties": {
-                                                    "type_category": {
-                                                        "enum": [
-                                                            "binary"
-                                                        ]
-                                                    }
-                                                }
-                                            },
-                                            "else": {
-                                                "if": {
-                                                    "properties": {
-                                                        "type": {
-                                                            "pattern": "^bool_$"
-                                                        }
-                                                    }
-                                                },
-                                                "then": {
-                                                    "properties": {
-                                                        "type_category": {
-                                                            "enum": [
-                                                                "boolean"
-                                                            ]
-                                                        }
-                                                    }
-                                                },
-                                                "else": {
-                                                    "if": {
-                                                        "properties": {
-                                                            "type": {
-                                                                "pattern": "^list_\\(\\w+(,[0-9]+)?\\)$|^large_list\\(\\w+\\)$"
-                                                            }
-                                                        }
-                                                    },
-                                                    "then": {
-                                                        "properties": {
-                                                            "type_category": {
-                                                                "enum": [
-                                                                    "array"
-                                                                ]
-                                                            }
-                                                        }
-                                                    },
-                                                    "else": {
-                                                        "if": {
-                                                            "properties": {
-                                                                "type": {
-                                                                    "pattern": "^map_$|^struct$|^field$|^schema$"
-                                                                }
-                                                            }
-                                                        },
-                                                        "then": {
-                                                            "properties": {
-                                                                "type_category": {
-                                                                    "enum": [
-                                                                        "object"
-                                                                    ]
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        "$ref": "#/definitions/int_types"
+                    },
+                    {
+                        "$ref": "#/definitions/float_types"
+                    },
+                    {
+                        "$ref": "#/definitions/string_types"
+                    },
+                    {
+                        "$ref": "#/definitions/timestamp_types"
+                    },
+                    {
+                        "$ref": "#/definitions/binary_types"
+                    },
+                    {
+                        "$ref": "#/definitions/boolean_types"
+                    },
+                    {
+                        "$ref": "#/definitions/list_types"
+                    },
+                    {
+                        "$ref": "#/definitions/struct_types"
                     }
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "title": "The column name"
-                    },
-                    "description": {
-                        "type": "string",
-                        "title": "A description of this field",
-                        "default": ""
-                    },
-                    "type": {
-                        "type": "string",
-                        "title": "The data type. Should be one of the Arrow types",
-                        "pattern": "^null$|^u?int(8|16|32|64)$|^float(16|32|64)$|^decimal128\\(\\d+,\\d+\\)$|^string$|^large_string$|^utf8$|^large_utf8$|^time32\\((s|ms)\\)$|^time64\\((us|ns)\\)$|^date(32|64)$|^timestamp\\((s|ms|us|ns)\\)$|^binary(\\([0-9]+\\))?$|^large_binary$|^bool_$|^large_list<.+>$|^list_<.+>$|struct<.+>$"
-                    },
-                    "type_category": {
-                        "type": "string",
-                        "title": "The type category. The 'type' can be inferred from this if it is not provided",
-                        "enum": [
-                            "integer",
-                            "float",
-                            "string",
-                            "datetime",
-                            "boolean",
-                            "array",
-                            "object",
-                            "null",
-                            "binary"
-                        ]
-                    },
-                    "nullable": {
-                        "type": "boolean",
-                        "title": "Specifies if column is nullable (can have missing values) or not (cannot have missing values)"
-                    },
-                    "sensitive": {
-                        "type": "boolean",
-                        "title": "Specifies if the column contains personal or special category data"
-                    },
-                    "alias": {
-                        "type": "string",
-                        "title": "If this column contains a standard ID or other linking field but has a non-standard name, the alias can provide the standard name",
-                        "examples": [
-                            "nomis_id"
-                        ]
-                    },
-                    "foreign_key": {
-                        "type": "array",
-                        "title": "The list of foreign key relationships this column has, if any",
-                        "default": [],
-                        "examples": [
-                            [
-                                {
-                                    "table": "",
-                                    "columns": []
-                                }
-                            ]
-                        ],
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "type": "object",
-                                    "default": {},
-                                    "examples": [
-                                        {
-                                            "table": "",
-                                            "columns": []
-                                        }
-                                    ],
-                                    "required": [
-                                        "table",
-                                        "columns"
-                                    ],
-                                    "properties": {
-                                        "table": {
-                                            "type": "string",
-                                            "title": "The table name",
-                                            "default": "",
-                                            "examples": [
-                                                ""
-                                            ]
-                                        },
-                                        "columns": {
-                                            "type": "array",
-                                            "title": "The list of column names",
-                                            "default": []
-                                        }
-                                    },
-                                    "additionalProperties": true
-                                }
-                            ]
-                        }
-                    },
-                    "unique": {
-                        "type": "boolean",
-                        "title": "Specifies if the values in the column must be unique",
-                        "default": false
-                    },
-                    "enum": {
-                        "type": "array",
-                        "title": "An array of valid values that can exist in this column. Note NULL/None is not required, please use nullable property to define if column is nullable.",
-                        "examples": [
-                            [
-                                "Y",
-                                "N"
-                            ],
-                            [
-                                0,
-                                1,
-                                2,
-                                3,
-                                4
-                            ],
-                            [
-                                "England",
-                                "Northern Ireland",
-                                "Scotland",
-                                "Wales"
-                            ]
-                        ]
-                    },
-                    "pattern": {
-                        "type": "string",
-                        "title": "regex pattern that can be used to validate data in this column"
-                    },
-                    "minimum": {
-                        "type": [
-                            "null",
-                            "number"
-                        ],
-                        "title": "The minumum value a numerical type can take",
-                        "default": null
-                    },
-                    "maximum": {
-                        "type": [
-                            "null",
-                            "number"
-                        ],
-                        "title": "The maximum value a numerical type can take",
-                        "default": null
-                    },
-                    "minLength": {
-                        "type": [
-                            "null",
-                            "number"
-                        ],
-                        "title": "The minimum length a string type can have",
-                        "default": null
-                    },
-                    "maxLength": {
-                        "type": [
-                            "null",
-                            "number"
-                        ],
-                        "title": "The maximum length a string type can have",
-                        "default": null
-                    }
-                },
-                "additionalProperties": true
+                ]
             }
         }
     },

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -44,7 +44,7 @@ def assert_meta_col_conversion(
             assert getattr(yolo_converter, funname)(in_type) == out_type
 
         if len(record) != 0:
-            fail_info = "Explected no warning as options.ignore_warnings = True."
+            fail_info = "Expected no warning as options.ignore_warnings = True."
             pytest.fail(fail_info)
     else:
         with pytest.warns(None) as record:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -65,7 +65,8 @@ def test_columns_default():
         [{"name": "test", "type": "time32"}],
         [{"name": "test", "type": "time64"}],
         [{"name": "test", "type": "timestamp"}],
-        [{"name": "test", "type_category": "datetime", "type": "timestamp"}],
+        [{"name": "test", "type_category": "timestamp", "type": "timestamp"}],
+        [{"name": "test", "type_category": "datetime", "type": "timestamp(s)"}],
     ],
 )
 def test_columns_validation_error(col_input: Any):
@@ -81,7 +82,7 @@ def test_columns_validation_error(col_input: Any):
         [{"name": "test", "type_category": "integer"}],
         [{"name": "test", "type_category": "float"}],
         [{"name": "test", "type_category": "string"}],
-        [{"name": "test", "type_category": "datetime"}],
+        [{"name": "test", "type_category": "timestamp"}],
         [{"name": "test", "type_category": "binary"}],
         [{"name": "test", "type_category": "boolean"}],
         [{"name": "test", "type": "int8"}],
@@ -118,7 +119,7 @@ def test_columns_validation_error(col_input: Any):
         [{"name": "test", "type_category": "integer", "type": "int8"}],
         [{"name": "test", "type_category": "float", "type": "float32"}],
         [{"name": "test", "type_category": "string", "type": "string"}],
-        [{"name": "test", "type_category": "datetime", "type": "timestamp(ms)"}],
+        [{"name": "test", "type_category": "timestamp", "type": "timestamp(ms)"}],
         [{"name": "test", "type_category": "binary", "type": "binary(128)"}],
         [{"name": "test", "type_category": "binary", "type": "binary"}],
         [{"name": "test", "type_category": "boolean", "type": "bool_"}],

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -338,3 +338,50 @@ def test_unpack_complex_data_type(data_type, expected):
     meta = Metadata()
     assert _unpack_complex_data_type(data_type) == expected
     assert meta.unpack_complex_data_type(data_type) == expected
+
+
+def test_set_col_types_from_type_category():
+    test_dict = {
+        "name": "test",
+        "description": "test",
+        "file_format": "test",
+        "sensitive": False,
+        "columns": [
+            {"name": "test_null", "type_category": "null"},
+            {"name": "test_integer", "type_category": "integer"},
+            {"name": "test_float", "type_category": "float"},
+            {"name": "test_string", "type_category": "string"},
+            {"name": "test_timestamp", "type_category": "timestamp"},
+            {"name": "test_binary", "type_category": "binary"},
+            {"name": "test_boolean", "type_category": "boolean"},
+            {"name": "test_list", "type_category": "list"},
+            {"name": "test_struct", "type_category": "struct"},
+        ],
+    }
+    meta = Metadata.from_dict(test_dict)
+    with pytest.warns(UserWarning):
+        meta.set_col_types_from_type_category()
+
+    for c in meta.columns:
+        default_type_cat = c["name"].replace("test_", "")
+        expected_type = meta.default_type_category_lookup.get(default_type_cat)
+        assert c["type"] == expected_type
+
+    new_dict = {
+        "null": "null",
+        "integer": "uint8",
+        "float": "decimal128(2,5)",
+        "string": "large_string",
+        "timestamp": "timestamp(us)",
+        "binary": "large_binary",
+        "boolean": "bool_",
+        "list": "large_list<null>",
+        "struct": "map_<null>",
+    }
+
+    meta2 = Metadata.from_dict(test_dict)
+    meta2.set_col_types_from_type_category(lambda x: new_dict.get(x["type_category"]))
+
+    for c in meta2.columns:
+        default_type_cat = c["name"].replace("test_", "")
+        assert c["type"] == new_dict.get(default_type_cat)


### PR DESCRIPTION
## Added

- Have added `definitions` which are now referenced in other parts of the schema to remove duplicate regex expressions
- Have added `additional_col_properties` to `definitions` which are the generic properties for each object in the schema's `columns` property.
- Have added `<name>_types` to `definitions` which is the specific regex expression for `type` and allowed `type_category` for each of the type groups we support. 