### PR TITLE
remove wrangler/pydbtools requirement in glue converter

### DIFF
--- a/mojap_metadata/converters/glue_converter/__init__.py
+++ b/mojap_metadata/converters/glue_converter/__init__.py
@@ -5,11 +5,7 @@ import re
 import warnings
 
 import importlib.resources as pkg_resources
-import pydbtools as pydb
 
-from awswrangler.catalog import (
-    delete_table_if_exists,
-)
 from dataclasses import dataclass
 from mojap_metadata.converters import (
     BaseConverter,
@@ -465,11 +461,13 @@ class GlueTable(BaseConverter):
             metadata, database_name=database_name, table_location=table_location
         )
         # create database if it doesn't exist
-        pydb.start_query_execution_and_wait(
-            f"CREATE DATABASE IF NOT EXISTS {database_name};"
+        _start_query_execution_and_wait(
+            database_name, f"CREATE DATABASE IF NOT EXISTS {database_name};"
         )
 
-        delete_table_if_exists(database=database_name, table=metadata.name)
+        _start_query_execution_and_wait(
+            f"DELETE TABLE IF EXISTS {database_name}.{metadata.name}"
+        )
         glue_client.create_table(**boto_dict)
 
         if (
@@ -484,8 +482,8 @@ class GlueTable(BaseConverter):
             )
             warnings.warn(w)
         elif run_msck_repair:
-            pydb.start_query_execution_and_wait(
-                f"msck repair table {database_name}.{metadata.name}"
+            _start_query_execution_and_wait(
+                database_name, f"msck repair table {database_name}.{metadata.name}"
             )
 
     def generate_to_meta(self, database: str, table: str) -> Metadata:
@@ -598,6 +596,27 @@ def _convert_opts_into_dict(spec_opts: SpecOptions):
     for k, _ in spec_opts.__annotations__:
         out_dict[k] = getattr(spec_opts, k)
     return out_dict
+
+
+def _start_query_execution_and_wait(db: str, sql: str):
+    ath = boto3.client("athena")
+    QueryExecutionContext = {"Database": db}
+    WorkGroup = "primary"
+    res = ath.start_query_execution(
+        QueryString=sql,
+        QueryExecutionContext=QueryExecutionContext,
+        WorkGroup=WorkGroup,
+    )
+    query_exec_id = res["QueryExecutionId"]
+    while (response := ath.get_query_execution(QueryExecutionId=query_exec_id)):
+        state = response["QueryExecution"]["Status"]["State"]
+        if state not in ["SUCCEEDED", "FAILED"]:
+            time.sleep(0.25)
+        else:
+            break
+
+    if not state == "SUCCEEDED":
+        raise ValueError(response["QueryExecution"]["Status"].get("StateChangeReason"))
 
 
 def generate_spec_from_template(

--- a/mojap_metadata/converters/glue_converter/__init__.py
+++ b/mojap_metadata/converters/glue_converter/__init__.py
@@ -2,6 +2,7 @@ import boto3
 import json
 import os
 import re
+import time
 import warnings
 
 import importlib.resources as pkg_resources

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "mojap-metadata"
-version = "1.11.1"
+version = "1.11.2"
 description = "A python package to manage metadata"
 license = "MIT"
 authors = ["MoJ Data Engineering <dataengineering@digital.justice.gov.uk>"]
@@ -14,7 +14,6 @@ parameterized = "0.7.*"
 PyYAML = ">=5.4.1"
 pyarrow = { version = ">=3.0.0", optional = true }
 etl-manager = { version = "^7.4", optional = true }
-pydbtools = { version = "^5.3.0", optional = true }
 psycopg2 = { version = "^2.9.2", optional = true,  extras = ["postgres"]}
 "testing.postgresql" ={ version = "^1.3.0", optional = true,  extras = ["postgres"]}
 SQLAlchemy = { version = "^1.4.27", optional = true,  extras = ["postgres"]}
@@ -30,7 +29,6 @@ moto = "^2.2.11"
 [tool.poetry.extras]
 arrow = ["pyarrow"]
 etl-manager = ["etl-manager"]
-glue = ["pydbtools"]
 postgres = ["psycopg2","testing.postgresql","SQLAlchemy"]
 
 

--- a/tests/test_glue_converter.py
+++ b/tests/test_glue_converter.py
@@ -5,6 +5,7 @@ import pydbtools as pydb
 
 from tests.helper import assert_meta_col_conversion, valid_types, get_meta
 from moto import mock_glue
+from mojap_metadata.converters import glue_converter
 from mojap_metadata.converters.glue_converter import (
     GlueConverter,
     GlueTable,
@@ -180,7 +181,9 @@ def test_gluetable_generate_from_meta(glue_client, monkeypatch):
         {"database_name": "cool_database", "table_location": "s3://buckets/are/cool"},
     )
 
-    monkeypatch.setattr(pydb, "start_query_execution_and_wait", lambda x: None)
+    monkeypatch.setattr(
+        glue_converter, "_start_query_execution_and_wait", lambda x: None
+    )
     glue_client.create_database(DatabaseInput={"Name": meta.database_name})
 
     # ignore the warnings as I don't want to run msck repair table
@@ -197,7 +200,9 @@ def test_gluetable_msck_warnings(glue_client, monkeypatch):
         "csv",
         {"database_name": "cool_database", "table_location": "s3://buckets/are/cool"},
     )
-    monkeypatch.setattr(pydb, "start_query_execution_and_wait", lambda x: None)
+    monkeypatch.setattr(
+        glue_converter, "_start_query_execution_and_wait", lambda x: None
+    )
     glue_client.create_database(DatabaseInput={"Name": meta.database_name})
     gt = GlueTable()
     with pytest.warns(Warning):
@@ -210,7 +215,9 @@ def test_gluetable_generate_to_meta(glue_client, monkeypatch):
         {"database_name": "cool_database", "table_location": "s3://buckets/are/cool"},
     )
 
-    monkeypatch.setattr(pydb, "start_query_execution_and_wait", lambda x: None)
+    monkeypatch.setattr(
+        glue_converter, "_start_query_execution_and_wait", lambda x: None
+    )
     # create the mock table and generate the meta from the mock table
     with mock_glue():
         glue_client.create_database(DatabaseInput={"Name": meta.database_name})


### PR DESCRIPTION
### Why have you done this Stephen?
pydbtools relies on awswrangler which comes bundled with pandas and numpy, two huge packages that take up a metric ton of space. Why is this important you ask? Because if this function is to be used with aws lambda to create or manage glue schemas on the fly, this will put the package payload over the default 50mb limit. 

### Considerations etc
- *Why have you got a 0.25 second sleep?! Won't that ruin everything?!?!111?!!*
No, it's the same sleep time that awswrangler uses in the `wait_query` function that is ultimately used in `pydbtools.start_query_execution_and_wait` 
- *did you test it?* 
Yes, sort of - I replaced like for like functionality so the modified tests _should_ do just fine 

<3 Stephen x