### PR TITLE
update decimal logic in sqlalchemy converter

### DIFF
--- a/mojap_metadata/converters/sqlalchemy_converter/__init__.py
+++ b/mojap_metadata/converters/sqlalchemy_converter/__init__.py
@@ -53,7 +53,12 @@ class SQLAlchemyConverter(BaseConverter):
         return dtype
 
     def _convert_to_decimal(self, col_type) -> str:
-        return f"decimal128({str(col_type.precision)},{str(col_type.scale)})"
+        if col_type.precision is None:
+            return f"decimal128(38,10)"
+        elif col_type.scale is None:
+            return f"decimal128({str(col_type.precision)},0)"
+        else:
+            return f"decimal128({str(col_type.precision)},{str(col_type.scale)})"
 
     def _get_table_description(self, table, schema) -> str:
         description = ""

--- a/mojap_metadata/converters/sqlalchemy_converter/__init__.py
+++ b/mojap_metadata/converters/sqlalchemy_converter/__init__.py
@@ -55,11 +55,13 @@ class SQLAlchemyConverter(BaseConverter):
     def _convert_to_decimal(
         self,
         col_type,
-        default_decimal_precision: int = 38,
-        default_decimal_scale: int = 10,
+        default_decimal_precision: int = None,
+        default_decimal_scale: int = None,
     ) -> str:
+        default_precision = default_decimal_precision or 38
+        default_scale = default_decimal_scale or 10
         if col_type.precision is None:
-            return f"decimal128({default_decimal_precision},{default_decimal_scale})"
+            return f"decimal128({default_precision},{default_scale})"
         elif col_type.scale is None:
             return f"decimal128({str(col_type.precision)},0)"
         else:
@@ -78,8 +80,8 @@ class SQLAlchemyConverter(BaseConverter):
     def convert_to_mojap_type(
         self,
         col_type,
-        default_decimal_precision: int = 38,
-        default_decimal_scale: int = 10,
+        default_decimal_precision: int = None,
+        default_decimal_scale: int = None,
     ) -> str:
         """_Converts a SQLAlchemy data type into a mojap data type_
 
@@ -103,8 +105,8 @@ class SQLAlchemyConverter(BaseConverter):
         self,
         table: str,
         schema: str,
-        default_decimal_precision: int = 38,
-        default_decimal_scale: int = 10,
+        default_decimal_precision: int = None,
+        default_decimal_scale: int = None,
     ) -> Metadata:
         """_Generates a Metadata object from a specified table and schema_
 
@@ -145,8 +147,8 @@ class SQLAlchemyConverter(BaseConverter):
     def generate_to_meta_list(
         self,
         schema: str,
-        default_decimal_precision: int = 38,
-        default_decimal_scale: int = 10,
+        default_decimal_precision: int = None,
+        default_decimal_scale: int = None,
     ) -> list:
         """_Generates a list of Metadata objects for all the tables in a schema_
 

--- a/tests/test_sqlalchemy_mapping.py
+++ b/tests/test_sqlalchemy_mapping.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 from sqlalchemy import create_engine
 from sqlalchemy.types import (
     String,
@@ -21,13 +22,14 @@ from sqlalchemy.types import (
 )
 from mojap_metadata.converters.sqlalchemy_converter import SQLAlchemyConverter
 
+logging.basicConfig(filename="db.log")
+logging.getLogger("sqlalchemy.engine").setLevel(logging.ERROR)
 
 @pytest.mark.parametrize(
     "inputtype,expected",
     [
         (Integer(), "int32"),
         (BIGINT(), "int64"),
-        (Float(precision=10, decimal_return_scale=2), "float64"),
         (String(), "string"),
         (String(length=4000), "string"),
         (VARCHAR(length=255), "string"),
@@ -40,8 +42,11 @@ from mojap_metadata.converters.sqlalchemy_converter import SQLAlchemyConverter
         (BLOB(), "binary"),
         (VARBINARY(), "binary"),
         (LargeBinary(), "binary"),
+        (Float(precision=10, decimal_return_scale=2), "float64"),
         (NUMERIC(precision=15, scale=2), "decimal128(15,2)"),
         (DECIMAL(precision=8, scale=0), "decimal128(8,0)"),
+        (DECIMAL(), "decimal128(38,10)"),
+        (DECIMAL(10), "decimal128(10,0)"),
         (JSON(), "string"),
         ("Unknown", "string"),
     ],

--- a/tests/test_sqlalchemy_mapping.py
+++ b/tests/test_sqlalchemy_mapping.py
@@ -25,6 +25,7 @@ from mojap_metadata.converters.sqlalchemy_converter import SQLAlchemyConverter
 logging.basicConfig(filename="db.log")
 logging.getLogger("sqlalchemy.engine").setLevel(logging.ERROR)
 
+
 @pytest.mark.parametrize(
     "inputtype,expected",
     [
@@ -55,4 +56,23 @@ def test_convert_to_mojap_type(inputtype: type, expected: str):
     engine = create_engine("sqlite:///:memory:")
     pc = SQLAlchemyConverter(engine)
     actual = pc.convert_to_mojap_type(inputtype)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "inputtype,expected",
+    [
+        (DECIMAL(precision=8, scale=0), "decimal128(8,0)"),
+        (DECIMAL(), "decimal128(30,2)"),
+        (DECIMAL(10), "decimal128(10,0)"),
+    ],
+)
+def test_convert_to_mojap_type_decimal_default(inputtype: type, expected: str):
+    engine = create_engine("sqlite:///:memory:")
+    pc = SQLAlchemyConverter(engine)
+    actual = pc.convert_to_mojap_type(
+        inputtype,
+        default_decimal_precision=30,
+        default_decimal_scale=2,
+    )
     assert actual == expected

--- a/tests/test_sqlalchemy_mapping.py
+++ b/tests/test_sqlalchemy_mapping.py
@@ -20,7 +20,10 @@ from sqlalchemy.types import (
     VARBINARY,
     JSON,
 )
-from mojap_metadata.converters.sqlalchemy_converter import SQLAlchemyConverter
+from mojap_metadata.converters.sqlalchemy_converter import (
+    SQLAlchemyConverter,
+    SQLAlchemyConverterOptions,
+)
 
 logging.basicConfig(filename="db.log")
 logging.getLogger("sqlalchemy.engine").setLevel(logging.ERROR)
@@ -69,10 +72,9 @@ def test_convert_to_mojap_type(inputtype: type, expected: str):
 )
 def test_convert_to_mojap_type_decimal_default(inputtype: type, expected: str):
     engine = create_engine("sqlite:///:memory:")
-    pc = SQLAlchemyConverter(engine)
-    actual = pc.convert_to_mojap_type(
-        inputtype,
-        default_decimal_precision=30,
-        default_decimal_scale=2,
+    opt = SQLAlchemyConverterOptions(
+        default_decimal_precision=30, default_decimal_scale=2
     )
+    pc = SQLAlchemyConverter(engine, options=opt)
+    actual = pc.convert_to_mojap_type(inputtype)
     assert actual == expected


### PR DESCRIPTION
Pass in default decimal precision and scale when unknown:

https://learn.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql?view=sql-server-ver16

This is set to 38 and 10 which are the values used in managed pipelines, but the values can be modified if required