### PR TITLE
update regex pattern for float types

### DIFF
--- a/mojap_metadata/metadata/specs/table_schema.json
+++ b/mojap_metadata/metadata/specs/table_schema.json
@@ -193,7 +193,7 @@
                     "properties": {
                         "type": {
                             "type": "string",
-                            "pattern": "^float(16|32|64)$|^decimal128\\(\\d+,\\d+\\)$"
+                            "pattern": "^float(16|32|64)$|^decimal128\\(\\d+, {0,1}\\d+\\)$"
                         },
                         "type_category": {
                             "enum": [


### PR DESCRIPTION
allowing a single space (or no space) in the regex pattern for `decimal128()` float type. Was failing validation because the type in arrow was something like `decimal128(7, 2)` but the pattern did not allow for a space inside the brackets