### PR TITLE
remove space from decimal in glueconverter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.14.1 - 2023-09-13
+
+- Remove spaces in decimal types in GlueConverter
+
 ## v1.14.0 - 2023-09-04
 
 - Updated metadata schema to v1.4.0

--- a/mojap_metadata/converters/glue_converter/__init__.py
+++ b/mojap_metadata/converters/glue_converter/__init__.py
@@ -267,6 +267,7 @@ class GlueConverter(BaseConverter):
         if coltype.startswith("decimal128"):
             t, is_supported = self._default_type_converter.get("decimal128")
             brackets = coltype.split("(")[1].split(")")[0]
+            brackets = brackets.replace(" ", "")
             t = f"{t}({brackets})"
         elif coltype.startswith("binary"):
             coltype_ = coltype.split("(", 1)[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "mojap-metadata"
-version = "1.14.0"
+version = "1.14.1"
 description = "A python package to manage metadata"
 license = "MIT"
 authors = ["MoJ Data Engineering <dataengineering@digital.justice.gov.uk>"]

--- a/tests/test_glue_converter.py
+++ b/tests/test_glue_converter.py
@@ -45,6 +45,7 @@ def test_converter_accepts_type(meta_type):
         ("float32", "float", None),
         ("float64", "double", None),
         ("decimal128(0,38)", "decimal(0,38)", None),
+        ("decimal128(0, 38)", "decimal(0,38)", None),
         ("decimal128(1,2)", "decimal(1,2)", None),
         ("time32(s)", None, "error"),
         ("time32(ms)", None, "error"),


### PR DESCRIPTION
While metadata schema v1.4.0 allows for spaces in decimal128(x, y) types because that's the case in arrow/parquet, this is illegal in the aws Glue catalogue. Madly an error doesn't get thrown when applying the schema, e.g. with `GlueTable.generate_from_meta`, but does when you try to query it. This will remove that space.