### PR TITLE
SQLAlchemy: SQLServer test

### DIFF
--- a/tests/test_sqlalchemy_converter.py
+++ b/tests/test_sqlalchemy_converter.py
@@ -36,6 +36,7 @@ password = os.getenv("DB_PASSWORD")
 # The following dialects are skipped by default, tested if value is set to 'True'
 test_oracle = os.getenv("TEST_ORACLE", "False") == "True"
 test_postgres = os.getenv("TEST_POSTGRES", "False") == "True"
+test_sqlserver = os.getenv("TEST_SQLSERVER", "False") == "True"
 
 
 # Create engines
@@ -56,6 +57,10 @@ def create_sqlachemy_engine(dialect):
     elif dialect == "postgres":
         engine = create_engine(
             f"postgresql://postgres:{password}@localhost:5432/postgres"
+        )
+    elif dialect == "sqlserver":
+        engine = create_engine(
+            f"mssql+pyodbc://{user}:{password}@127.0.0.1:1433/test_mojap_metadata?driver=ODBC+Driver+17+for+SQL+Server"
         )
     return engine
 
@@ -194,6 +199,19 @@ mojap_metadata/v1.4.0.json",
             ["my_string_10"],
             "int32",
             marks=(pytest.mark.skipif(test_oracle is False, reason="skip oracle test")),
+        ),
+        pytest.param(
+            "sqlserver",
+            "dbo",
+            "this is my table",
+            "this is the comment",
+            ["my_string_10"],
+            "bool",
+            marks=(
+                pytest.mark.skipif(
+                    test_sqlserver is False, reason="skip sqlserver test"
+                )
+            ),
         ),
     ],
 )


### PR DESCRIPTION
This describes a test for SQLServer dialect (supported by SQLAlchemy). I have tested this by connecting to an RDS sql server instance in EM's dev environment (via an SSM session using port forwarding locally) and creating a database `test_mojap_metadata`. The test passes locally for now, but I should create a docker sqlserver container so others can test themselves. Opening the PR for other's to look at but not ready for merging yet.